### PR TITLE
Added some additional functionality to Error Framework

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@babel/code-frame": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
-      "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
+      "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
       "dev": true,
       "requires": {
         "@babel/highlight": "^7.0.0"
@@ -155,9 +155,9 @@
       "dev": true
     },
     "acorn": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.2.0.tgz",
-      "integrity": "sha512-8oe72N3WPMjA+2zVG71Ia0nXZ8DpQH+QyyHO+p06jT8eg8FGG3FbcUIi8KziHlAfheJQZeoqbvq1mQSQHXKYLw==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.2.1.tgz",
+      "integrity": "sha512-JD0xT5FCRDNyjDda3Lrg/IxFscp9q4tiYtxE1/nOzlKCk7hIRuYjhq1kCNkbPjMRMZuFq20HNQn1I9k8Oj0E+Q==",
       "dev": true
     },
     "acorn-jsx": {
@@ -847,9 +847,9 @@
       "dev": true
     },
     "eslint": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.0.1.tgz",
-      "integrity": "sha512-DyQRaMmORQ+JsWShYsSg4OPTjY56u1nCjAmICrE8vLWqyLKxhFXOthwMj1SA8xwfrv0CofLNVnqbfyhwCkaO0w==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.1.0.tgz",
+      "integrity": "sha512-QhrbdRD7ofuV09IuE2ySWBz0FyXCq0rriLTZXZqaWSI79CVtHVRdkFuFTViiqzZhkCgfOh9USpriuGN2gIpZDQ==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -858,7 +858,7 @@
         "cross-spawn": "^6.0.5",
         "debug": "^4.0.1",
         "doctrine": "^3.0.0",
-        "eslint-scope": "^4.0.3",
+        "eslint-scope": "^5.0.0",
         "eslint-utils": "^1.3.1",
         "eslint-visitor-keys": "^1.0.0",
         "espree": "^6.0.0",
@@ -866,34 +866,35 @@
         "esutils": "^2.0.2",
         "file-entry-cache": "^5.0.1",
         "functional-red-black-tree": "^1.0.1",
-        "glob-parent": "^3.1.0",
+        "glob-parent": "^5.0.0",
         "globals": "^11.7.0",
         "ignore": "^4.0.6",
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
-        "inquirer": "^6.2.2",
+        "inquirer": "^6.4.1",
         "is-glob": "^4.0.0",
         "js-yaml": "^3.13.1",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.3.0",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.14",
         "minimatch": "^3.0.4",
         "mkdirp": "^0.5.1",
         "natural-compare": "^1.4.0",
         "optionator": "^0.8.2",
         "progress": "^2.0.0",
         "regexpp": "^2.0.1",
-        "semver": "^5.5.1",
-        "strip-ansi": "^4.0.0",
-        "strip-json-comments": "^2.0.1",
+        "semver": "^6.1.2",
+        "strip-ansi": "^5.2.0",
+        "strip-json-comments": "^3.0.1",
         "table": "^5.2.3",
-        "text-table": "^0.2.0"
+        "text-table": "^0.2.0",
+        "v8-compile-cache": "^2.0.3"
       },
       "dependencies": {
         "ajv": {
-          "version": "6.10.1",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.1.tgz",
-          "integrity": "sha512-w1YQaVGNC6t2UCPjEawK/vo/dG8OOrVtUmhBT1uJJYxbl5kU2Tj3v6LGqBcsysN1yhuCStJCCA3GqdvKY8sqXQ==",
+          "version": "6.10.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+          "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
           "dev": true,
           "requires": {
             "fast-deep-equal": "^2.0.1",
@@ -903,9 +904,9 @@
           }
         },
         "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
           "dev": true
         },
         "ansi-styles": {
@@ -939,6 +940,14 @@
             "semver": "^5.5.0",
             "shebang-command": "^1.2.0",
             "which": "^1.2.9"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "5.7.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+              "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+              "dev": true
+            }
           }
         },
         "globals": {
@@ -953,23 +962,19 @@
           "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
           "dev": true
         },
-        "js-yaml": {
-          "version": "3.13.1",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-          "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
-          "dev": true,
-          "requires": {
-            "argparse": "^1.0.7",
-            "esprima": "^4.0.0"
-          }
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
         },
         "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "^4.1.0"
           }
         },
         "supports-color": {
@@ -1023,9 +1028,9 @@
       }
     },
     "eslint-module-utils": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.4.0.tgz",
-      "integrity": "sha512-14tltLm38Eu3zS+mt0KvILC3q8jyIAH518MlG+HO0p+yK885Lb1UHTY/UgR91eOyGdmxAPb+OLoW4znqIT6Ndw==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.4.1.tgz",
+      "integrity": "sha512-H6DOj+ejw7Tesdgbfs4jeS4YMFrT8uI8xwd1gtQqXssaR0EQ26L+2O/w6wkYFy2MymON0fTwHmXBvvfLNZVZEw==",
       "dev": true,
       "requires": {
         "debug": "^2.6.8",
@@ -1060,9 +1065,9 @@
       }
     },
     "eslint-plugin-import": {
-      "version": "2.18.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.18.0.tgz",
-      "integrity": "sha512-PZpAEC4gj/6DEMMoU2Df01C5c50r7zdGIN52Yfi7CvvWaYssG7Jt5R9nFG5gmqodxNOz9vQS87xk6Izdtpdrig==",
+      "version": "2.18.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.18.2.tgz",
+      "integrity": "sha512-5ohpsHAiUBRNaBWAF08izwUGlbrJoJJ+W9/TBwsGoR1MnlgfwMIKrFeSjWbt6moabiXW9xNvtFz+97KHRfI4HQ==",
       "dev": true,
       "requires": {
         "array-includes": "^3.0.3",
@@ -1072,8 +1077,8 @@
         "eslint-import-resolver-node": "^0.3.2",
         "eslint-module-utils": "^2.4.0",
         "has": "^1.0.3",
-        "lodash": "^4.17.11",
         "minimatch": "^3.0.4",
+        "object.values": "^1.1.0",
         "read-pkg-up": "^2.0.0",
         "resolve": "^1.11.0"
       },
@@ -1126,9 +1131,9 @@
           "dev": true
         },
         "semver": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.2.0.tgz",
-          "integrity": "sha512-jdFC1VdUGT/2Scgbimf7FSx9iJLXoqfglSF+gJeuNWVpiE37OIbc1jywR/GJyFdz3mnkz2/id0L0J/cr0izR5A==",
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true
         }
       }
@@ -1140,9 +1145,9 @@
       "dev": true
     },
     "eslint-plugin-react": {
-      "version": "7.14.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.14.2.tgz",
-      "integrity": "sha512-jZdnKe3ip7FQOdjxks9XPN0pjUKZYq48OggNMd16Sk+8VXx6JOvXmlElxROCgp7tiUsTsze3jd78s/9AFJP2mA==",
+      "version": "7.14.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.14.3.tgz",
+      "integrity": "sha512-EzdyyBWC4Uz2hPYBiEJrKCUi2Fn+BJ9B/pJQcjw5X+x/H2Nm59S4MJIvL4O5NEE0+WbnQwEBxWY03oUk+Bc3FA==",
       "dev": true,
       "requires": {
         "array-includes": "^3.0.3",
@@ -1174,9 +1179,9 @@
       "dev": true
     },
     "eslint-scope": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
-      "integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
+      "integrity": "sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==",
       "dev": true,
       "requires": {
         "esrecurse": "^4.1.0",
@@ -1184,10 +1189,13 @@
       }
     },
     "eslint-utils": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.3.1.tgz",
-      "integrity": "sha512-Z7YjnIldX+2XMcjr7ZkgEsOj/bREONV60qYeB/bjMAqqqZ4zxKyWX+BOUkdmRmA9riiIPVvo5x86m5elviOk0Q==",
-      "dev": true
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.0.tgz",
+      "integrity": "sha512-7ehnzPaP5IIEh1r1tkjuIrxqhNkzUJa9z3R92tLJdZIVdWaczEhr3EbhGtsMrVxi1KeR8qA7Off6SWc5WNQqyQ==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^1.0.0"
+      }
     },
     "eslint-visitor-keys": {
       "version": "1.0.0",
@@ -1434,9 +1442,9 @@
       "dev": true
     },
     "get-stdin": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
-      "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-7.0.0.tgz",
+      "integrity": "sha512-zRKcywvrXlXsA0v0i9Io4KDRaAw7+a1ZpjRwl9Wox8PFlVCCHra7E9c4kqXCoCM9nR5tBkaTTZRBoCm60bFqTQ==",
       "dev": true
     },
     "getpass": {
@@ -1462,24 +1470,12 @@
       }
     },
     "glob-parent": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
-      "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.0.0.tgz",
+      "integrity": "sha512-Z2RwiujPRGluePM6j699ktJYxmPpJKCfpGA13jz2hmFZC7gKetzrWvg5KN3+OsIFmydGyZ1AVwERCq1w/ZZwRg==",
       "dev": true,
       "requires": {
-        "is-glob": "^3.1.0",
-        "path-dirname": "^1.0.0"
-      },
-      "dependencies": {
-        "is-glob": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-          "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "^2.1.0"
-          }
-        }
+        "is-glob": "^4.0.1"
       }
     },
     "globals": {
@@ -1682,12 +1678,6 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
           "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-          "dev": true
-        },
-        "lodash": {
-          "version": "4.17.14",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
-          "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==",
           "dev": true
         },
         "strip-ansi": {
@@ -2592,12 +2582,6 @@
         "error-ex": "^1.2.0"
       }
     },
-    "path-dirname": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
-      "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
-      "dev": true
-    },
     "path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
@@ -2660,26 +2644,70 @@
       "dev": true
     },
     "pkg-conf": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-2.1.0.tgz",
-      "integrity": "sha1-ISZRTKbyq/69FoWW3xi6V4Z/AFg=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-3.1.0.tgz",
+      "integrity": "sha512-m0OTbR/5VPNPqO1ph6Fqbj7Hv6QU7gR/tQW40ZqrL1rjgCU85W6C1bJn0BItuJqnR98PWzw7Z8hHeChD1WrgdQ==",
       "dev": true,
       "requires": {
-        "find-up": "^2.0.0",
-        "load-json-file": "^4.0.0"
+        "find-up": "^3.0.0",
+        "load-json-file": "^5.2.0"
       },
       "dependencies": {
-        "load-json-file": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
-          "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^4.0.0",
-            "pify": "^3.0.0",
-            "strip-bom": "^3.0.0"
+            "locate-path": "^3.0.0"
           }
+        },
+        "load-json-file": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-5.3.0.tgz",
+          "integrity": "sha512-cJGP40Jc/VXUsp8/OrnyKyTZ1y6v/dphm3bioS+RrKXjK2BB6wHUd6JptZEFDGgGahMT+InnZO5i1Ei9mpC8Bw==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.15",
+            "parse-json": "^4.0.0",
+            "pify": "^4.0.1",
+            "strip-bom": "^3.0.0",
+            "type-fest": "^0.3.0"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+          "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "dev": true
         },
         "parse-json": {
           "version": "4.0.0",
@@ -2692,9 +2720,9 @@
           }
         },
         "pify": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
           "dev": true
         },
         "strip-bom": {
@@ -3174,12 +3202,12 @@
       "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
     },
     "standard": {
-      "version": "13.0.1",
-      "resolved": "https://registry.npmjs.org/standard/-/standard-13.0.1.tgz",
-      "integrity": "sha512-oUYnSs9J0SuA6j6z5spsF5sm/Q4LUyUhBeHPen0mCORVXi6jo73K+MPdlxXq+5rhU/eLCR3uebbiPplyZIBaLQ==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/standard/-/standard-13.1.0.tgz",
+      "integrity": "sha512-h3NaMzsa88+/xtjXCMvdn6EWWdlodsI/HvtsQF+EGwrF9kVNwNha9TkFABU6bSBoNfC79YDyIAq9ekxOMBFkuw==",
       "dev": true,
       "requires": {
-        "eslint": "~6.0.1",
+        "eslint": "~6.1.0",
         "eslint-config-standard": "13.0.1",
         "eslint-config-standard-jsx": "7.0.0",
         "eslint-plugin-import": "~2.18.0",
@@ -3187,19 +3215,19 @@
         "eslint-plugin-promise": "~4.2.1",
         "eslint-plugin-react": "~7.14.2",
         "eslint-plugin-standard": "~4.0.0",
-        "standard-engine": "~10.0.0"
+        "standard-engine": "~11.0.1"
       }
     },
     "standard-engine": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/standard-engine/-/standard-engine-10.0.0.tgz",
-      "integrity": "sha512-91BjmzIRZbFmyOY73R6vaDd/7nw5qDWsfpJW5/N+BCXFgmvreyfrRg7oBSu4ihL0gFGXfnwCImJm6j+sZDQQyw==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/standard-engine/-/standard-engine-11.0.1.tgz",
+      "integrity": "sha512-WZQ5PpEDfRzPFk+H9xvKVQPQIxKnAQB2cb2Au4NyTCtdw5R0pyMBUZLbPXyFjnlhe8Ae+zfNrWU4m6H5b7cEAg==",
       "dev": true,
       "requires": {
         "deglob": "^3.0.0",
-        "get-stdin": "^6.0.0",
+        "get-stdin": "^7.0.0",
         "minimist": "^1.1.0",
-        "pkg-conf": "^2.0.0"
+        "pkg-conf": "^3.1.0"
       },
       "dependencies": {
         "minimist": {
@@ -3280,9 +3308,9 @@
       }
     },
     "strip-json-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
+      "integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==",
       "dev": true
     },
     "supports-color": {
@@ -3292,17 +3320,29 @@
       "dev": true
     },
     "table": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/table/-/table-5.4.1.tgz",
-      "integrity": "sha512-E6CK1/pZe2N75rGZQotFOdmzWQ1AILtgYbMAbAjvms0S1l5IDB47zG3nCnFGB/w+7nB3vKofbLXCH7HPBo864w==",
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/table/-/table-5.4.4.tgz",
+      "integrity": "sha512-IIfEAUx5QlODLblLrGTTLJA7Tk0iLSGBvgY8essPRVNGHAzThujww1YqHLs6h3HfTg55h++RzLHH5Xw/rfv+mg==",
       "dev": true,
       "requires": {
-        "ajv": "^6.9.1",
-        "lodash": "^4.17.11",
+        "ajv": "^6.10.2",
+        "lodash": "^4.17.14",
         "slice-ansi": "^2.1.0",
         "string-width": "^3.0.0"
       },
       "dependencies": {
+        "ajv": {
+          "version": "6.10.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+          "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^2.0.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
         "ansi-regex": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
@@ -3631,6 +3671,12 @@
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
       "dev": true
     },
+    "type-fest": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
+      "integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==",
+      "dev": true
+    },
     "typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
@@ -3680,6 +3726,12 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
       "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+    },
+    "v8-compile-cache": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.0.3.tgz",
+      "integrity": "sha512-CNmdbwQMBjwr9Gsmohvm0pbL954tJrNzf6gWL3K+QMQf00PF7ERGrEiLgjuU3mKreLC2MeGhUsNV9ybTbLgd3w==",
+      "dev": true
     },
     "validate-npm-package-license": {
       "version": "3.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/central-services-error-handling",
-  "version": "7.2.1-snapshot",
+  "version": "7.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/central-services-error-handling",
-  "version": "7.2.1",
+  "version": "7.2.1-snapshot",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/central-services-error-handling",
-  "version": "7.2.0",
+  "version": "7.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/central-services-error-handling",
-  "version": "7.1.3",
+  "version": "7.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -540,6 +540,7 @@
       "version": "2.20.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
       "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+      "dev": true,
       "optional": true
     },
     "concat-map": {
@@ -1497,6 +1498,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
       "integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
+      "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
         "optimist": "^0.6.1",
@@ -1507,7 +1509,8 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
         }
       }
     },
@@ -2126,9 +2129,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.14",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
-      "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw=="
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "lodash.includes": {
       "version": "4.3.0",
@@ -2247,7 +2250,8 @@
     "minimist": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.5.tgz",
-      "integrity": "sha1-16oye87PUY+RBqxrjwA/o7zqhWY="
+      "integrity": "sha1-16oye87PUY+RBqxrjwA/o7zqhWY=",
+      "dev": true
     },
     "mkdirp": {
       "version": "0.5.1",
@@ -2286,7 +2290,8 @@
     "neo-async": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
-      "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw=="
+      "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
+      "dev": true
     },
     "nice-try": {
       "version": "1.0.5",
@@ -2505,6 +2510,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "dev": true,
       "requires": {
         "minimist": "~0.0.1",
         "wordwrap": "~0.0.2"
@@ -2513,7 +2519,8 @@
         "wordwrap": {
           "version": "0.0.3",
           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+          "dev": true
         }
       }
     },
@@ -3634,6 +3641,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.0.tgz",
       "integrity": "sha512-W+jrUHJr3DXKhrsS7NUVxn3zqMOFn0hL/Ei6v0anCIMoKC93TjcflTagwIHLW7SfMFfiQuktQyFVCFHGUE0+yg==",
+      "dev": true,
       "optional": true,
       "requires": {
         "commander": "~2.20.0",
@@ -3644,6 +3652,7 @@
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true,
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/central-services-error-handling",
-  "version": "7.2.0",
+  "version": "7.2.1",
   "description": "Hapi error handling module",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/central-services-error-handling",
-  "version": "7.1.3",
+  "version": "7.2.0",
   "description": "Hapi error handling module",
   "main": "src/index.js",
   "scripts": {
@@ -35,7 +35,8 @@
   "homepage": "https://github.com/mojaloop/central-services-error-handling#readme",
   "dependencies": {
     "@modusbox/mojaloop-sdk-standard-components": "0.0.36",
-    "@mojaloop/central-services-shared": "6.4.1"
+    "@mojaloop/central-services-shared": "6.4.1",
+    "lodash": "^4.17.15"
   },
   "devDependencies": {
     "@hapi/boom": "7.4.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/central-services-error-handling",
-  "version": "7.2.1-snapshot",
+  "version": "7.2.1",
   "description": "Hapi error handling module",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   ],
   "author": "Dwolla",
   "contributors": [
-    "Georgi Georgiev <georgi.georgiev@modusbox.com>"
+    "ModusBox"
   ],
   "license": "Apache-2.0",
   "bugs": {
@@ -36,7 +36,7 @@
   "dependencies": {
     "@modusbox/mojaloop-sdk-standard-components": "0.0.36",
     "@mojaloop/central-services-shared": "6.4.1",
-    "lodash": "^4.17.15"
+    "lodash": "4.17.15"
   },
   "devDependencies": {
     "@hapi/boom": "7.4.2",
@@ -45,7 +45,7 @@
     "npm-audit-resolver": "1.5.0",
     "pre-commit": "1.2.2",
     "sinon": "7.3.2",
-    "standard": "13.0.1",
+    "standard": "13.1.0",
     "tap-xunit": "2.4.1",
     "tape": "4.11.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/central-services-error-handling",
-  "version": "7.2.1",
+  "version": "7.2.1-snapshot",
   "description": "Hapi error handling module",
   "main": "src/index.js",
   "scripts": {

--- a/src/enums.js
+++ b/src/enums.js
@@ -84,11 +84,12 @@ const MojaloopTypes = {
 const populateErrorTypes = (errorCodes, errorTypes) => {
   const newErrorCodes = {}
   for (const [errorCodeKey, errorCodeValue] of Object.entries(errorCodes)) {
-    for (const errorTypeValue of Object.values(errorTypes)) {
+    for (const [errorTypeKey, errorTypeValue] of Object.entries(errorTypes)) {
       const regExp = new RegExp(errorTypeValue.regex)
       if (regExp.test(errorCodeValue.code)) {
         const newErrorCodeValue = _.cloneDeep(errorCodeValue)
         _.set(newErrorCodeValue, 'type', errorTypeValue)
+        _.set(newErrorCodeValue, 'type.name', errorTypeKey)
         _.set(newErrorCodes, errorCodeKey, newErrorCodeValue)
       }
     }

--- a/src/enums.js
+++ b/src/enums.js
@@ -88,6 +88,7 @@ const populateErrorTypes = (errorCodes, errorTypes) => {
       const regExp = new RegExp(errorTypeValue.regex)
       if (regExp.test(errorCodeValue.code)) {
         const newErrorCodeValue = _.cloneDeep(errorCodeValue)
+        _.set(newErrorCodeValue, 'name', errorCodeKey)
         _.set(newErrorCodeValue, 'type', errorTypeValue)
         _.set(newErrorCodeValue, 'type.name', errorTypeKey)
         _.set(newErrorCodes, errorCodeKey, newErrorCodeValue)

--- a/src/enums.js
+++ b/src/enums.js
@@ -98,23 +98,46 @@ const populateErrorTypes = (errorCodes, errorTypes) => {
 }
 
 /**
+ * Returns an object representing a Mojaloop API spec error code map using the error code as the key
+ *
+ * @param errorCodes {object} - Mojaloop API spec error code enums
+ * @returns {object} - Object representing a Mojaloop API Error map using the error code as the key with each record having the associated name
+ */
+const errorCodesToMap = (errorCodes) => {
+  const newErrorCodeMap = {}
+  for (const [errorCodeKey, errorCodeValue] of Object.entries(errorCodes)) {
+    const newErrorCodeValue = _.cloneDeep(errorCodeValue)
+    _.set(newErrorCodeValue, 'name', errorCodeKey)
+    _.set(newErrorCodeMap, errorCodeValue.code.toString(), newErrorCodeValue)
+  }
+  return newErrorCodeMap
+}
+
+/**
  *  Mojaloop API spec error enums with associated type enums
  */
 const FSPIOPErrorCodes = populateErrorTypes(MojaloopSDKError.MojaloopApiErrorCodes, MojaloopTypes)
 
 /**
- * Returns an object representing a Mojaloop API spec error object given its error code
+ *  Mojaloop API spec error map enums with associated type enums by error code as the key map
+ */
+const FSPIOPErrorCodeMap = errorCodesToMap(FSPIOPErrorCodes)
+
+/**
+ * Returns an object representing a Mojaloop API spec error object given its error code using super fast hash lookup
  *
  * @param code {number/string} - Mojaloop API spec error code (four digit integer as number or string)
  * @returns {object} - Object representing the Mojaloop API spec error
  */
 const findFSPIOPErrorCode = (code) => {
-  const stringCodeValue = code.toString()
-  const ec = Object.keys(FSPIOPErrorCodes).find(ec => {
-    return FSPIOPErrorCodes[ec].code === stringCodeValue
-  })
+  let ec
+  if (code) {
+    const stringCodeValue = code.toString()
+    ec = FSPIOPErrorCodeMap[stringCodeValue]
+  }
+
   if (ec) {
-    return FSPIOPErrorCodes[ec]
+    return ec
   }
   return undefined
 }
@@ -122,5 +145,6 @@ const findFSPIOPErrorCode = (code) => {
 module.exports = {
   FSPIOPErrorCodes,
   FSPIOPErrorTypes: MojaloopTypes,
+  FSPIOPErrorCodeMap,
   findFSPIOPErrorCode
 }

--- a/src/enums.js
+++ b/src/enums.js
@@ -22,15 +22,104 @@
  * Gates Foundation
  - Name Surname <name.surname@gatesfoundation.com>
 
- * Neal Donnan <neal.donnan@modusbox.com>
+ * ModusBox
+ - Neal Donnan <neal.donnan@modusbox.com>
+ - Juan Correa <juan.correa@modusbox.com>
+ - Miguel de Barros <miguel.debarros@modusbox.com>
 
  --------------
  ******/
 
 'use strict'
 
-const Errors = require('@modusbox/mojaloop-sdk-standard-components').Errors
+const _ = require('lodash')
+
+const MojaloopSDKError = require('@modusbox/mojaloop-sdk-standard-components').Errors
+
+/**
+ *  Mojaloop API spec error type enums
+ */
+const MojaloopTypes = {
+  GENERIC_COMMUNICATION_ERROR: {
+    regex: '^10[0-9]{2}$',
+    description: 'Generic Communication Error'
+  },
+  GENERIC_SERVER_ERROR: {
+    regex: '^20[0-9]{2}$',
+    description: 'Generic Server Error'
+  },
+  GENERIC_CLIENT_ERROR: {
+    regex: '^30[0-9]{2}$',
+    description: 'Generic Client Error'
+  },
+  CLIENT_VALIDATION_ERROR: {
+    regex: '^31[0-9]{2}$',
+    description: 'Client Validation Error'
+  },
+  IDENTIFIER_ERROR: {
+    regex: '^32[0-9]{2}$',
+    description: 'Identifier Error'
+  },
+  EXPIRED_ERROR: {
+    regex: '^33[0-9]{2}$',
+    description: 'Expired Error'
+  },
+  PAYER_ERROR: {
+    regex: '^4[0-9]{3}$',
+    description: 'Payer Error'
+  },
+  PAYEE_ERROR: {
+    regex: '^5[0-9]{3}$',
+    description: 'Payee Error'
+  }
+}
+
+/**
+ * Returns an object representing a Mojaloop API spec error code combined with error types enums
+ *
+ * @param errorCodes {object} - Mojaloop API spec error code enums
+ * @param errorTypes {object} - Mojaloop API spec error type enums
+ * @returns {object} - Object representing the Mojaloop API spec error enums with associated types
+ */
+const populateErrorTypes = (errorCodes, errorTypes) => {
+  const newErrorCodes = {}
+  for (const [errorCodeKey, errorCodeValue] of Object.entries(errorCodes)) {
+    for (const errorTypeValue of Object.values(errorTypes)) {
+      const regExp = new RegExp(errorTypeValue.regex)
+      if (regExp.test(errorCodeValue.code)) {
+        const newErrorCodeValue = _.cloneDeep(errorCodeValue)
+        _.set(newErrorCodeValue, 'type', errorTypeValue)
+        _.set(newErrorCodes, errorCodeKey, newErrorCodeValue)
+      }
+    }
+  }
+  return newErrorCodes
+}
+
+/**
+ *  Mojaloop API spec error enums with associated type enums
+ */
+const FSPIOPErrorCodes = populateErrorTypes(MojaloopSDKError.MojaloopApiErrorCodes, MojaloopTypes)
+
+/**
+ * Returns an object representing a Mojaloop API spec error object given its error code
+ *
+ * @param code {number/string} - Mojaloop API spec error code (four digit integer as number or string)
+ * @returns {object} - Object representing the Mojaloop API spec error
+ */
+const findFSPIOPErrorCode = (code) => {
+  const stringCodeValue = code.toString()
+  const ec = Object.keys(FSPIOPErrorCodes).find(ec => {
+    return FSPIOPErrorCodes[ec].code === stringCodeValue
+  })
+  if (ec) {
+    return FSPIOPErrorCodes[ec]
+  }
+  return undefined
+}
 
 module.exports = {
-  FSPIOPErrorCodes: Errors.MojaloopApiErrorCodes
+  FSPIOPErrorCodes,
+  FSPIOPErrorTypes: MojaloopTypes,
+  findFSPIOPErrorCode
 }

--- a/src/factory.js
+++ b/src/factory.js
@@ -22,7 +22,10 @@
  * Gates Foundation
  - Name Surname <name.surname@gatesfoundation.com>
 
- * Neal Donnan <neal.donnan@modusbox.com>
+ * ModusBox
+ - Neal Donnan <neal.donnan@modusbox.com>
+ - Juan Correa <juan.correa@modusbox.com>
+ - Miguel de Barros <miguel.debarros@modusbox.com>
 
  --------------
  ******/

--- a/src/factory.js
+++ b/src/factory.js
@@ -210,11 +210,7 @@ const reformatFSPIOPError = (error, apiErrorCode = ErrorEnums.FSPIOPErrorCodes.I
  */
 const createFSPIOPErrorFromErrorInformation = (errorInformation, replyTo) => {
   const errorCode = validateFSPIOPErrorCode(errorInformation.errorCode)
-  if (!errorCode) {
-    throw createFSPIOPError(ErrorEnums.INTERNAL_SERVER_ERROR, `Invalid errorCode provided - ${JSON.stringify(errorInformation.errorCode)}.`, replyTo, ErrorEnums.FSPIOPErrorCodes.INTERNAL_SERVER_ERROR, errorInformation.extensionList)
-  } else {
-    return createFSPIOPError(errorCode, errorInformation.errorDescription, errorInformation.errorDescription, replyTo, errorInformation.extensionList, true)
-  }
+  return createFSPIOPError(errorCode, errorInformation.errorDescription, errorInformation.errorDescription, replyTo, errorInformation.extensionList, true)
 }
 
 /**

--- a/src/factory.js
+++ b/src/factory.js
@@ -222,7 +222,7 @@ const createFSPIOPErrorFromErrorInformation = (errorInformation, replyTo) => {
  * @throws {FSPIOPError} - Internal Server Error indicating that the error code is invalid.
  */
 const validateFSPIOPErrorCode = (code) => {
-  const errorMessage = 'Validation for failed due to error code being invalid'
+  const errorMessage = 'Validation failed due to error code being invalid'
   let codeToValidate
   if (typeof code === 'number' || typeof code === 'string') { // check to see if this is a normal error code represented by a number or string
     codeToValidate = code

--- a/src/factory.js
+++ b/src/factory.js
@@ -84,10 +84,14 @@ class FSPIOPError extends MojaloopFSPIOPError {
  * @param cause the original Error
  * @param replyTo the FSP to notify of the error
  * @param extensions additional information to associate with the error
- * @returns {FSPIOPError}
+ * @returns {FSPIOPError} - create the specified error, will fall back to INTERNAL_SERVER_ERROR if the apiErrorCode is undefined
  */
 const createFSPIOPError = (apiErrorCode, message, cause, replyTo, extensions) => {
-  return new FSPIOPError(cause, message, replyTo, apiErrorCode, extensions)
+  if (apiErrorCode) {
+    return new FSPIOPError(cause, message, replyTo, apiErrorCode, extensions)
+  } else {
+    return new FSPIOPError(cause, message, replyTo, Errors.INTERNAL_SERVER_ERROR, extensions)
+  }
 }
 
 /**

--- a/src/factory.js
+++ b/src/factory.js
@@ -84,14 +84,10 @@ class FSPIOPError extends MojaloopFSPIOPError {
  * @param cause the original Error
  * @param replyTo the FSP to notify of the error
  * @param extensions additional information to associate with the error
- * @returns {FSPIOPError} - create the specified error, will fall back to INTERNAL_SERVER_ERROR if the apiErrorCode is undefined
+ * @returns {FSPIOPError}
  */
 const createFSPIOPError = (apiErrorCode, message, cause, replyTo, extensions) => {
-  if (apiErrorCode) {
-    return new FSPIOPError(cause, message, replyTo, apiErrorCode, extensions)
-  } else {
-    return new FSPIOPError(cause, message, replyTo, Errors.INTERNAL_SERVER_ERROR, extensions)
-  }
+  return new FSPIOPError(cause, message, replyTo, apiErrorCode, extensions)
 }
 
 /**

--- a/src/handler.js
+++ b/src/handler.js
@@ -22,6 +22,10 @@
  * Gates Foundation
  - Name Surname <name.surname@gatesfoundation.com>
 
+ * ModusBox
+ - Neal Donnan <neal.donnan@modusbox.com>
+ - Rajiv Mothilal <rajiv.mothilal@modusbox.com>
+
  --------------
  ******/
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,36 @@
+/*****
+ License
+ --------------
+ Copyright © 2017 Bill & Melinda Gates Foundation
+ The Mojaloop files are made available by the Bill & Melinda Gates Foundation under the Apache License, Version 2.0 (the "License") and you may not use these files except in compliance with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, the Mojaloop files are distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+
+ Contributors
+ --------------
+ This is the official list of the Mojaloop project contributors for this file.
+ Names of the original copyright holders (individuals or organizations)
+ should be listed with a '*' in the first column. People who have
+ contributed from an organization can be listed under the organization
+ that actually holds the copyright for their contributions (see the
+ Gates Foundation organization for an example). Those individuals should have
+ their names indented and be marked with a '-'. Email address can be added
+ optionally within square brackets <email>.
+
+ * Gates Foundation
+ - Name Surname <name.surname@gatesfoundation.com>
+
+ * ModusBox
+ - Neal Donnan <neal.donnan@modusbox.com>
+ - Juan Correa <juan.correa@modusbox.com>
+ - Rajiv Mothilal <rajiv.mothilal@modusbox.com>
+ - Miguel de Barros <miguel.debarros@modusbox.com>
+
+ --------------
+ ******/
+
 'use strict'
 
 const Handler = require('./handler')
@@ -5,14 +38,14 @@ const ValidationErrors = require('./validation-errors')
 const Factory = require('./factory')
 const Enums = require('./enums')
 
-exports.plugin = {
+const plugin = {
   name: 'error-handler',
   register: function (server) {
     server.ext('onPreResponse', Handler.onPreResponse)
   }
 }
 
-exports.validateRoutes = (options = {}) => {
+const validateRoutes = (options = {}) => {
   options.abortEarly = false
   const language = options.language || {}
   language.key = '{{!key}} '
@@ -20,9 +53,18 @@ exports.validateRoutes = (options = {}) => {
   return options
 }
 
-exports.InvalidBodyError = ValidationErrors.InvalidBodyError
-exports.InvalidQueryParameterError = ValidationErrors.InvalidQueryParameterError
-exports.InvalidUriParameterError = ValidationErrors.InvalidUriParameterError
-exports.InvalidHeaderError = ValidationErrors.InvalidHeaderError
-exports.Factory = Factory
-exports.Enums = Enums
+module.exports = {
+  plugin,
+  validateRoutes,
+  InvalidBodyError: ValidationErrors.InvalidBodyError,
+  InvalidQueryParameterError: ValidationErrors.InvalidQueryParameterError,
+  InvalidUriParameterError: ValidationErrors.InvalidUriParameterError,
+  InvalidHeaderError: ValidationErrors.InvalidHeaderError,
+  Factory: Factory,
+  Enums: Enums,
+  CreateFSPIOPError: Factory.createFSPIOPError,
+  CreateFSPIOPErrorFromJoiError: Factory.createFSPIOPErrorFromJoiError,
+  CreateInternalServerFSPIOPError: Factory.createInternalServerFSPIOPError,
+  ReformatFSPIOPError: Factory.reformatFSPIOPError,
+  FindFSPIOPErrorCode: Enums.findFSPIOPErrorCode
+}

--- a/test/enums.test.js
+++ b/test/enums.test.js
@@ -70,5 +70,13 @@ Test('Enum should', enumTest => {
     test.end()
   })
 
+  enumTest.test('test FSPIOPErrorCodeMaps contains every error found in the FSPIOPErrorCodes object using the findFSPIOPErrorCode method', function (test) {
+    for (const errorCodeValue of Object.values(ErrorEnums.FSPIOPErrorCodes)) {
+      const errorCodeResult = ErrorEnums.findFSPIOPErrorCode(errorCodeValue.code)
+      test.ok(errorCodeResult)
+    }
+    test.end()
+  })
+
   enumTest.end()
 })

--- a/test/enums.test.js
+++ b/test/enums.test.js
@@ -1,0 +1,74 @@
+/*****
+ License
+ --------------
+ Copyright © 2017 Bill & Melinda Gates Foundation
+ The Mojaloop files are made available by the Bill & Melinda Gates Foundation under the Apache License, Version 2.0 (the "License") and you may not use these files except in compliance with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, the Mojaloop files are distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+
+ Contributors
+ --------------
+ This is the official list of the Mojaloop project contributors for this file.
+ Names of the original copyright holders (individuals or organizations)
+ should be listed with a '*' in the first column. People who have
+ contributed from an organization can be listed under the organization
+ that actually holds the copyright for their contributions (see the
+ Gates Foundation organization for an example). Those individuals should have
+ their names indented and be marked with a '-'. Email address can be added
+ optionally within square brackets <email>.
+
+ * Gates Foundation
+ - Name Surname <name.surname@gatesfoundation.com>
+
+ * ModusBox
+ - Neal Donnan <neal.donnan@modusbox.com>
+ - Juan Correa <juan.correa@modusbox.com>
+ - Miguel de Barros <miguel.debarros@modusbox.com>
+
+ --------------
+ ******/
+
+'use strict'
+
+const Test = require('tape')
+const ErrorEnums = require('../src/enums')
+
+Test('Enum should', enumTest => {
+  enumTest.test('return correct error code string', function (test) {
+    const fspiopErrorCode = ErrorEnums.findFSPIOPErrorCode(ErrorEnums.FSPIOPErrorCodes.PAYEE_FSP_INSUFFICIENT_LIQUIDITY.code)
+    test.ok(fspiopErrorCode)
+    test.equal(fspiopErrorCode.code, ErrorEnums.FSPIOPErrorCodes.PAYEE_FSP_INSUFFICIENT_LIQUIDITY.code)
+    test.equal(fspiopErrorCode.message, ErrorEnums.FSPIOPErrorCodes.PAYEE_FSP_INSUFFICIENT_LIQUIDITY.message)
+    test.end()
+  })
+
+  enumTest.test('return correct error code integer', function (test) {
+    const fspiopErrorCode = ErrorEnums.findFSPIOPErrorCode(parseInt(ErrorEnums.FSPIOPErrorCodes.PAYEE_FSP_INSUFFICIENT_LIQUIDITY.code))
+    test.ok(fspiopErrorCode)
+    test.equal(fspiopErrorCode.code, ErrorEnums.FSPIOPErrorCodes.PAYEE_FSP_INSUFFICIENT_LIQUIDITY.code)
+    test.equal(fspiopErrorCode.message, ErrorEnums.FSPIOPErrorCodes.PAYEE_FSP_INSUFFICIENT_LIQUIDITY.message)
+    test.end()
+  })
+
+  enumTest.test('return undefined result with incorrect error code', function (test) {
+    const fspiopErrorCode = ErrorEnums.findFSPIOPErrorCode(parseInt('9999'))
+    test.equals(fspiopErrorCode, undefined)
+    test.end()
+  })
+
+  enumTest.test('test FSPIOPErrorTypes are correctly added to FSPIOPErrorCodes by validating each entry by its associated regex', function (test) {
+    const fspiopErrorCode = ErrorEnums.findFSPIOPErrorCode(ErrorEnums.FSPIOPErrorCodes.PAYEE_FSP_INSUFFICIENT_LIQUIDITY.code)
+    for (const errorCodeValue of Object.values(ErrorEnums.FSPIOPErrorCodes)) {
+      const regExp = new RegExp(errorCodeValue.type.regex)
+      test.ok(regExp.test(errorCodeValue.code))
+    }
+    test.ok(fspiopErrorCode)
+    test.equal(fspiopErrorCode.code, ErrorEnums.FSPIOPErrorCodes.PAYEE_FSP_INSUFFICIENT_LIQUIDITY.code)
+    test.equal(fspiopErrorCode.message, ErrorEnums.FSPIOPErrorCodes.PAYEE_FSP_INSUFFICIENT_LIQUIDITY.message)
+    test.end()
+  })
+
+  enumTest.end()
+})

--- a/test/factory.test.js
+++ b/test/factory.test.js
@@ -22,7 +22,10 @@
  * Gates Foundation
  - Name Surname <name.surname@gatesfoundation.com>
 
- * Neal Donnan <neal.donnan@modusbox.com>
+ * ModusBox
+ - Neal Donnan <neal.donnan@modusbox.com>
+ - Juan Correa <juan.correa@modusbox.com>
+ - Miguel de Barros <miguel.debarros@modusbox.com>
 
  --------------
  ******/

--- a/test/factory.test.js
+++ b/test/factory.test.js
@@ -256,7 +256,7 @@ Test('Factory should', factoryTest => {
   })
 
   factoryTest.test('validateFSPIOPErrorCode should validate an string errorCode', function (test) {
-    const errorCode = Errors.INTERNAL_SERVER_ERROR.code
+    const errorCode = `${Errors.INTERNAL_SERVER_ERROR.code}`
     try {
       const result = Factory.validateFSPIOPErrorCode(errorCode)
       test.deepEqual(result, Errors.INTERNAL_SERVER_ERROR)
@@ -268,13 +268,27 @@ Test('Factory should', factoryTest => {
   })
 
   factoryTest.test('validateFSPIOPErrorCode should validate an apiErrorCode errorCode enum', function (test) {
-    const errorCode = Errors.INTERNAL_SERVER_ERROR.code
+    const errorCode = Errors.INTERNAL_SERVER_ERROR
     try {
       const result = Factory.validateFSPIOPErrorCode(errorCode)
       test.deepEqual(result, Errors.INTERNAL_SERVER_ERROR)
     } catch (err) {
       test.ok(err instanceof Factory.FSPIOPError)
       test.fail(err)
+    }
+    test.end()
+  })
+
+  factoryTest.test('validateFSPIOPErrorCode should validate an invalid apiErrorCode errorCode enum', function (test) {
+    const errorCode = { test }
+    try {
+      const result = Factory.validateFSPIOPErrorCode(errorCode)
+      test.notOk(result)
+      test.fail()
+    } catch (err) {
+      test.ok(err instanceof Factory.FSPIOPError)
+      test.equal(err.apiErrorCode.code, Errors.INTERNAL_SERVER_ERROR.code)
+      test.equal(err.apiErrorCode.message, Errors.INTERNAL_SERVER_ERROR.message)
     }
     test.end()
   })

--- a/test/factory.test.js
+++ b/test/factory.test.js
@@ -42,7 +42,7 @@ Test('Factory should', factoryTest => {
       { key: 'testKey', value: 'testValue' }
     ])
     test.ok(fspiopError)
-    test.equal(fspiopError.apiErrorCode.code, '2000')
+    test.equal(fspiopError.apiErrorCode.code, Errors.SERVER_ERROR.code)
     test.end()
   })
 
@@ -50,7 +50,15 @@ Test('Factory should', factoryTest => {
     const fspiopError = Factory.createFSPIOPError(Errors.SERVER_ERROR, 'An error has occurred', { stack: 'Error:...' }, 'dfsp1')
     const apiErrorObject = fspiopError.toApiErrorObject()
     test.ok(fspiopError)
-    test.equal(apiErrorObject.errorInformation.errorCode, '2000')
+    test.equal(apiErrorObject.errorInformation.errorCode, Errors.SERVER_ERROR.code)
+    test.end()
+  })
+
+  factoryTest.test('create an FSPIOPError undefined apiErrorCode extensions', function (test) {
+    const fspiopError = Factory.createFSPIOPError(undefined, 'An error has occurred', { stack: 'Error:...' }, 'dfsp1')
+    const apiErrorObject = fspiopError.toApiErrorObject()
+    test.ok(fspiopError)
+    test.equal(apiErrorObject.errorInformation.errorCode, Errors.INTERNAL_SERVER_ERROR.code)
     test.end()
   })
 

--- a/test/factory.test.js
+++ b/test/factory.test.js
@@ -42,7 +42,7 @@ Test('Factory should', factoryTest => {
       { key: 'testKey', value: 'testValue' }
     ])
     test.ok(fspiopError)
-    test.equal(fspiopError.apiErrorCode.code, Errors.SERVER_ERROR.code)
+    test.equal(fspiopError.apiErrorCode.code, '2000')
     test.end()
   })
 
@@ -50,15 +50,7 @@ Test('Factory should', factoryTest => {
     const fspiopError = Factory.createFSPIOPError(Errors.SERVER_ERROR, 'An error has occurred', { stack: 'Error:...' }, 'dfsp1')
     const apiErrorObject = fspiopError.toApiErrorObject()
     test.ok(fspiopError)
-    test.equal(apiErrorObject.errorInformation.errorCode, Errors.SERVER_ERROR.code)
-    test.end()
-  })
-
-  factoryTest.test('create an FSPIOPError undefined apiErrorCode extensions', function (test) {
-    const fspiopError = Factory.createFSPIOPError(undefined, 'An error has occurred', { stack: 'Error:...' }, 'dfsp1')
-    const apiErrorObject = fspiopError.toApiErrorObject()
-    test.ok(fspiopError)
-    test.equal(apiErrorObject.errorInformation.errorCode, Errors.INTERNAL_SERVER_ERROR.code)
+    test.equal(apiErrorObject.errorInformation.errorCode, '2000')
     test.end()
   })
 

--- a/test/factory.test.js
+++ b/test/factory.test.js
@@ -55,10 +55,32 @@ Test('Factory should', factoryTest => {
   })
 
   factoryTest.test('create an FSPIOPError undefined apiErrorCode extensions', function (test) {
-    const fspiopError = Factory.createFSPIOPError(undefined, 'An error has occurred', { stack: 'Error:...' }, 'dfsp1')
-    const apiErrorObject = fspiopError.toApiErrorObject()
-    test.ok(fspiopError)
-    test.equal(apiErrorObject.errorInformation.errorCode, Errors.INTERNAL_SERVER_ERROR.code)
+    try {
+      const apiErrorCode = undefined
+      const fspiopError = Factory.createFSPIOPError(apiErrorCode, 'An error has occurred', { stack: 'Error:...' }, 'dfsp1')
+      const apiErrorObject = fspiopError.toApiErrorObject()
+      test.ok(fspiopError)
+      test.equal(apiErrorObject.errorInformation.errorCode, Errors.INTERNAL_SERVER_ERROR.code)
+      test.fail(`We should have thrown an error here as the apiErrorCode is ${apiErrorCode}`)
+    } catch (err) {
+      test.ok(err instanceof Factory.FSPIOPError)
+      test.equal(err.apiErrorCode.code, Errors.INTERNAL_SERVER_ERROR.code)
+    }
+    test.end()
+  })
+
+  factoryTest.test('create an FSPIOPError undefined apiErrorCode extensions', function (test) {
+    try {
+      const apiErrorCode = { foo: 'bar' }
+      const fspiopError = Factory.createFSPIOPError(apiErrorCode, 'An error has occurred', { stack: 'Error:...' }, 'dfsp1')
+      const apiErrorObject = fspiopError.toApiErrorObject()
+      test.ok(fspiopError)
+      test.equal(apiErrorObject.errorInformation.errorCode, Errors.INTERNAL_SERVER_ERROR.code)
+      test.fail(`We should have thrown an error here as the apiErrorCode is ${apiErrorCode}`)
+    } catch (err) {
+      test.ok(err instanceof Factory.FSPIOPError)
+      test.equal(err.apiErrorCode.code, Errors.INTERNAL_SERVER_ERROR.code)
+    }
     test.end()
   })
 

--- a/test/handler.test.js
+++ b/test/handler.test.js
@@ -1,29 +1,33 @@
 /*****
- License
- --------------
- Copyright © 2017 Bill & Melinda Gates Foundation
- The Mojaloop files are made available by the Bill & Melinda Gates Foundation under the Apache License, Version 2.0 (the "License") and you may not use these files except in compliance with the License. You may obtain a copy of the License at
+License
+--------------
+  Copyright © 2017 Bill & Melinda Gates Foundation
+The Mojaloop files are made available by the Bill & Melinda Gates Foundation under the Apache License, Version 2.0 (the "License") and you may not use these files except in compliance with the License. You may obtain a copy of the License at
 
- http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
- Unless required by applicable law or agreed to in writing, the Mojaloop files are distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+  Unless required by applicable law or agreed to in writing, the Mojaloop files are distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
- Contributors
- --------------
- This is the official list of the Mojaloop project contributors for this file.
- Names of the original copyright holders (individuals or organizations)
- should be listed with a '*' in the first column. People who have
- contributed from an organization can be listed under the organization
- that actually holds the copyright for their contributions (see the
- Gates Foundation organization for an example). Those individuals should have
- their names indented and be marked with a '-'. Email address can be added
- optionally within square brackets <email>.
+  Contributors
+--------------
+  This is the official list of the Mojaloop project contributors for this file.
+  Names of the original copyright holders (individuals or organizations)
+should be listed with a '*' in the first column. People who have
+contributed from an organization can be listed under the organization
+that actually holds the copyright for their contributions (see the
+Gates Foundation organization for an example). Those individuals should have
+their names indented and be marked with a '-'. Email address can be added
+optionally within square brackets <email>.
 
- * Gates Foundation
- - Name Surname <name.surname@gatesfoundation.com>
+* Gates Foundation
+- Name Surname <name.surname@gatesfoundation.com>
 
- --------------
- ******/
+* ModusBox
+- Neal Donnan <neal.donnan@modusbox.com>
+- Rajiv Mothilal <rajiv.mothilal@modusbox.com>
+
+--------------
+******/
 
 'use strict'
 


### PR DESCRIPTION
- Added Enum type for FSPIOPErrorTypes which include a description and associated regex.
- Added Types on to existing Error Enums which contain a description and a regex.
- Added method to find FSPIOPErrorCodes from a numerical or string code.
- Added tests to find FSPIOPErrorCodes from a numerical or string code functionality.
- Exposed static Factory methods at the main index.js level (capitalised).

Un-reviewed changes:
- Added 'name' to the FSPIOPErrorCodes enums. This is useful for comparisons (i.e. deep-equal, etc)
- Overloaded the FSPIOPError constructor to take in an additional parameter `useMessageAsDescription` to support creating FSPIOPError objects from raw errorInformation objects
- Added the 'cause' to be automatically added as an extension.
- Added createFSPIOPErrorFromErrorInformation - Factory method to create an FSPIOPError based on the errorInformation object being passed in.
- Added validateFSPIOPErrorCode - Validate a code against the Mojaloop API spec, returns the enum or throws an exception if invalid