### PR TITLE
Fix for #914 Extension Value fields in ExtensionList objects exceeding the size limit of 128

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/central-services-error-handling",
-  "version": "7.2.4",
+  "version": "7.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/central-services-error-handling",
-  "version": "7.2.4",
+  "version": "7.3.0",
   "description": "Hapi error handling module",
   "main": "src/index.js",
   "scripts": {

--- a/src/enums.js
+++ b/src/enums.js
@@ -143,9 +143,32 @@ const findFSPIOPErrorCode = (code) => {
   return undefined
 }
 
+/**
+ *  Mojaloop API spec Model Types related to ErrorInformation
+ */
+const MojaloopModelTypes = {
+  ExtensionKey: {
+    cardinality: 1,
+    type: 'string',
+    constraints: {
+      min: 1,
+      max: 32
+    }
+  },
+  ExtensionValue: {
+    cardinality: 1,
+    type: 'string',
+    constraints: {
+      min: 1,
+      max: 128
+    }
+  }
+}
+
 module.exports = {
   FSPIOPErrorCodes,
   FSPIOPErrorTypes: MojaloopTypes,
   FSPIOPErrorCodeMap,
-  findFSPIOPErrorCode
+  findFSPIOPErrorCode,
+  MojaloopModelTypes
 }

--- a/src/factory.js
+++ b/src/factory.js
@@ -124,11 +124,11 @@ class FSPIOPError extends MojaloopFSPIOPError {
       // const causeKeyValueFromExtensions = e.errorInformation.extensionList.find(keyValue => keyValue.key === 'cause')
       const causeKeyValueFromExtensions = e.errorInformation.extensionList.extension.find(keyValue => keyValue.key === 'cause')
       if (causeKeyValueFromExtensions) {
-        causeKeyValueFromExtensions.value = `${this.stack}\n${causeKeyValueFromExtensions.value}`
+        causeKeyValueFromExtensions.value = `${this.stack}\n${causeKeyValueFromExtensions.value}`.substring(ErrorEnums.MojaloopModelTypes.ExtensionValue.constraints.min - 1, ErrorEnums.MojaloopModelTypes.ExtensionValue.constraints.max) // truncate string to match Mojaloop API v1.0 Spec
       } else {
         const causeKeyValue = {
           key: 'cause',
-          value: this.stack
+          value: this.stack.substring(ErrorEnums.MojaloopModelTypes.ExtensionValue.constraints.min - 1, ErrorEnums.MojaloopModelTypes.ExtensionValue.constraints.max) // truncate string to match Mojaloop API v1.0 Spec
         }
         // TODO: Need to clarify ML API Specification for the correct model structure for the extensionList - catering for both scenarios until this can be clarified
         // e.errorInformation.extensionList.push(causeKeyValue)
@@ -142,7 +142,7 @@ class FSPIOPError extends MojaloopFSPIOPError {
       }
       const causeKeyValue = {
         key: 'cause',
-        value: this.stack
+        value: this.stack.substring(ErrorEnums.MojaloopModelTypes.ExtensionValue.constraints.min - 1, ErrorEnums.MojaloopModelTypes.ExtensionValue.constraints.max) // truncate string to match Mojaloop API v1.0 Spec
       }
       // TODO: Need to clarify ML API Specification for the correct model structure for the extensionList - catering for both scenarios until this can be clarified
       // e.errorInformation.extensionList.push(causeKeyValue)

--- a/test/factory.test.js
+++ b/test/factory.test.js
@@ -35,6 +35,7 @@
 const Test = require('tape')
 const Factory = require('../src/factory')
 const Errors = require('../src/enums').FSPIOPErrorCodes
+const ErrorModelTypes = require('../src/enums').MojaloopModelTypes
 
 Test('Factory should', factoryTest => {
   factoryTest.test('create an FSPIOPError with extensions', function (test) {
@@ -148,7 +149,7 @@ Test('Factory should', factoryTest => {
           extension: [
             {
               key: 'cause',
-              value: fspiopError.stack
+              value: fspiopError.stack.substring(ErrorModelTypes.ExtensionValue.constraints.min - 1, ErrorModelTypes.ExtensionValue.constraints.max) // truncate string to match Mojaloop API v1.0 Spec
             }
           ]
         }
@@ -174,7 +175,7 @@ Test('Factory should', factoryTest => {
           extension: [
             {
               key: 'cause',
-              value: fspiopError.stack
+              value: fspiopError.stack.substring(ErrorModelTypes.ExtensionValue.constraints.min - 1, ErrorModelTypes.ExtensionValue.constraints.max) // truncate string to match Mojaloop API v1.0 Spec
             }
           ]
         }
@@ -200,7 +201,7 @@ Test('Factory should', factoryTest => {
           extension: [
             {
               key: 'cause',
-              value: fspiopError.stack
+              value: fspiopError.stack.substring(ErrorModelTypes.ExtensionValue.constraints.min - 1, ErrorModelTypes.ExtensionValue.constraints.max) // truncate string to match Mojaloop API v1.0 Spec
             }
           ]
         }
@@ -228,7 +229,7 @@ Test('Factory should', factoryTest => {
             },
             {
               key: 'cause',
-              value: fspiopError.stack
+              value: fspiopError.stack.substring(ErrorModelTypes.ExtensionValue.constraints.min - 1, ErrorModelTypes.ExtensionValue.constraints.max) // truncate string to match Mojaloop API v1.0 Spec
             }
           ]
         }
@@ -260,7 +261,7 @@ Test('Factory should', factoryTest => {
             },
             {
               key: 'cause',
-              value: fspiopError.stack
+              value: fspiopError.stack.substring(ErrorModelTypes.ExtensionValue.constraints.min - 1, ErrorModelTypes.ExtensionValue.constraints.max) // truncate string to match Mojaloop API v1.0 Spec
             }
           ]
         }
@@ -308,7 +309,7 @@ Test('Factory should', factoryTest => {
             },
             {
               key: 'cause',
-              value: fspiopError.stack
+              value: fspiopError.stack.substring(ErrorModelTypes.ExtensionValue.constraints.min - 1, ErrorModelTypes.ExtensionValue.constraints.max) // truncate string to match Mojaloop API v1.0 Spec
             }
           ]
         }
@@ -330,7 +331,7 @@ Test('Factory should', factoryTest => {
           },
           {
             key: 'cause',
-            value: errorCause
+            value: errorCause.substring(ErrorModelTypes.ExtensionValue.constraints.min - 1, ErrorModelTypes.ExtensionValue.constraints.max) // truncate string to match Mojaloop API v1.0 Spec
           }
         ]
       }
@@ -349,7 +350,7 @@ Test('Factory should', factoryTest => {
             },
             {
               key: 'cause',
-              value: `${fspiopError.stack}\n${errorCause}`
+              value: `${fspiopError.stack}\n${errorCause}`.substring(ErrorModelTypes.ExtensionValue.constraints.min - 1, ErrorModelTypes.ExtensionValue.constraints.max) // truncate string to match Mojaloop API v1.0 Spec
             }
           ]
         }
@@ -371,7 +372,7 @@ Test('Factory should', factoryTest => {
           },
           {
             key: 'cause',
-            value: errorCause
+            value: errorCause.substring(ErrorModelTypes.ExtensionValue.constraints.min - 1, ErrorModelTypes.ExtensionValue.constraints.max) // truncate string to match Mojaloop API v1.0 Spec
           }
         ]
       }
@@ -390,12 +391,14 @@ Test('Factory should', factoryTest => {
             },
             {
               key: 'cause',
-              value: `${fspiopError.stack}\n${errorCause}`
+              value: `${fspiopError.stack}\n${errorCause}`.substring(ErrorModelTypes.ExtensionValue.constraints.min - 1, ErrorModelTypes.ExtensionValue.constraints.max) // truncate string to match Mojaloop API v1.0 Spec
             }
           ]
         }
       }
     })
+    const causeKeyValue = fspiopError.toApiErrorObject().errorInformation.extensionList.extension.find((keyValue) => keyValue.key === 'cause')
+    test.equal(causeKeyValue.value.length, 128)
     test.end()
   })
 
@@ -442,7 +445,7 @@ Test('Factory should', factoryTest => {
             },
             {
               key: 'cause',
-              value: fspiopError.stack
+              value: fspiopError.stack.substring(ErrorModelTypes.ExtensionValue.constraints.min - 1, ErrorModelTypes.ExtensionValue.constraints.max) // truncate string to match Mojaloop API v1.0 Spec
             }
           ]
         }
@@ -479,7 +482,7 @@ Test('Factory should', factoryTest => {
           extension: [
             {
               key: 'cause',
-              value: fspiopError.stack
+              value: fspiopError.stack.substring(ErrorModelTypes.ExtensionValue.constraints.min - 1, ErrorModelTypes.ExtensionValue.constraints.max) // truncate string to match Mojaloop API v1.0 Spec
             }
           ]
         }


### PR DESCRIPTION
- Truncated the cause-key value in the extensionList when converting an FSPIOPError to an API ErrorInformation object.
- link to issue: https://github.com/mojaloop/project/issues/914
