### PR TITLE
Handle specific Joi errors

### DIFF
--- a/src/factory.js
+++ b/src/factory.js
@@ -247,8 +247,8 @@ const createFSPIOPErrorFromJoiError = (error, cause, replyTo) => {
     params: `'${error.context.label}' URI path parameter`
   }
 
-  // If the error was caused by a missing header or path params respond with appropriate text
-  // indicating as much
+  // If the error was caused by a missing or invalid header or path params respond with appropriate
+  // text indicating as much
   const msg = (source && messages[source])
     ? messages[source]
     : error.context.label

--- a/src/factory.js
+++ b/src/factory.js
@@ -247,8 +247,8 @@ const createFSPIOPErrorFromJoiError = (error, cause, replyTo) => {
     params: `'${error.context.label}' URI path parameter`
   }
 
-  // If the error was caused by a missing or invalid header or path params respond with appropriate
-  // text indicating as much
+  // If the error was caused by a missing header or path params respond with appropriate text
+  // indicating as much
   const msg = (source && messages[source])
     ? messages[source]
     : error.context.label

--- a/test/factory.test.js
+++ b/test/factory.test.js
@@ -133,6 +133,60 @@ Test('Factory should', factoryTest => {
     test.end()
   })
 
+  factoryTest.test('create an FSPIOPError from a Joi error and invalid path parameter response with toApiErrorObject includeCauseExtension: false, truncateCause: true', function (test) {
+    const joiError = {
+      type: 'any.allowOnly',
+      context: {
+        label: 'Type'
+      }
+    }
+    const joiResponse = {
+      output: {
+        payload: {
+          validation: {
+            source: 'params'
+          }
+        }
+      }
+    }
+    const fspiopError = Factory.createFSPIOPErrorFromJoiError(joiError, joiResponse, 'dfsp1')
+    test.ok(fspiopError)
+    test.deepEqual(fspiopError.toApiErrorObject(), {
+      errorInformation: {
+        errorCode: '3101',
+        errorDescription: 'Malformed syntax - \'Type\' URI path parameter'
+      }
+    })
+    test.end()
+  })
+
+  factoryTest.test('create an FSPIOPError from a Joi error and missing header response with toApiErrorObject includeCauseExtension: false, truncateCause: true', function (test) {
+    const joiError = {
+      type: 'any.required',
+      context: {
+        label: 'content-type'
+      }
+    }
+    const joiResponse = {
+      output: {
+        payload: {
+          validation: {
+            source: 'header'
+          }
+        }
+      }
+    }
+    const fspiopError = Factory.createFSPIOPErrorFromJoiError(joiError, joiResponse, 'dfsp1')
+    test.ok(fspiopError)
+    test.deepEqual(fspiopError.toApiErrorObject(), {
+      errorInformation: {
+        errorCode: '3102',
+        errorDescription: 'Missing mandatory element - \'content-type\' HTTP header'
+      }
+    })
+    test.end()
+  })
+
   factoryTest.test('create an FSPIOPError from a Joi error with toApiErrorObject includeCauseExtension: false, truncateCause: true', function (test) {
     const joiError = {
       type: 'any.required',


### PR DESCRIPTION
Return more informative error responses for URI path parameter and header validation issues.